### PR TITLE
`man brew` probably deprecated?

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Features, usage and installation instructions are [summarised on the homepage](h
 3. Or use `brew search --desc <keyword>` to browse packages from the command line.
 
 ## More Documentation
-`brew help`, `man brew` or check [our documentation](https://docs.brew.sh/).
+`brew help` or check [our documentation](https://docs.brew.sh/).
 
 ## Troubleshooting
 First, please run `brew update` and `brew doctor`.


### PR DESCRIPTION
man brew
No manual entry for brew

If `man brew` is supposed to exist, I kindly ask for some hint where that should be.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
